### PR TITLE
(FM-7669) - Check if a dependency has been deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,25 @@ The following rake task is available:
 - `rake compare_dependencies[managed_modules,module,version,verbose,use_slack]` Compare specfified module and version against dependencies of other modules 
   - `managed_modules` Path to YAML file containing an array of modules to compare to
   - `module` Name of module on Puppet Forge using the syntax owner/name e.g. puppetlabs/stdlib
-  - `version` Semantic version to compare against e.g. 5.0.1
+  - `version` Semantic version to compare against e.g. 5.0.1. 
   - `verbose` Boolean stating whether to display matches as well as non-matches. Defaults to false.
   - `use_slack` Boolean stating whether to post output to Slack. See below for more details. Defaults to false.
   - `logs_file` Path to logs file. This argument is optional. If this is not specified, logs are not saved.
   
+The same logs are sent to logs file and to Slack if the arguments are added. Logs contain details about the module which is comparing against, the module being compared from managed_modules file and the dependencies being compared.
+e.g.
+- The module you are comparing against module_name is DEPRECATED.
+- The checked module module_name is DEPRECATED.
+- The dependency module module_name is DEPRECATED.
+- Comparing modules against *puppetlabs/stdlib* version *10.0.0*
+  Checking *puppetlabs/websphere_application_server*
+        puppetlabs/concat (>= 1.1.0 < 5.0.0) *doesn't match* 5.2.0
+        puppetlabs/ibm_installation_manager (>= 0.2.4 < 1.0.0) *matches* 0.6.0
+
+  
 ### Posting output to Slack
 By passing true to the `use_slack` argument of the `compare_dependencies` rake task, you can have the output of the comparison sent to a Slack channel. To do this see [here](https://api.slack.com/tutorials/slack-apps-hello-world) on setting up a webhook on your Slack workspace, then supply the webhook to metadata-json-deps by specifying an environment variable called `METADATA_JSON_DEPS_SLACK_WEBHOOK` containing the webhook generated from Slack.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,3 @@ e.g.
   
 ### Posting output to Slack
 By passing true to the `use_slack` argument of the `compare_dependencies` rake task, you can have the output of the comparison sent to a Slack channel. To do this see [here](https://api.slack.com/tutorials/slack-apps-hello-world) on setting up a webhook on your Slack workspace, then supply the webhook to metadata-json-deps by specifying an environment variable called `METADATA_JSON_DEPS_SLACK_WEBHOOK` containing the webhook generated from Slack.
-
-
-
-
-

--- a/lib/metadata_json_deps/forge_helper.rb
+++ b/lib/metadata_json_deps/forge_helper.rb
@@ -18,21 +18,7 @@ module MetadataJsonDeps
       version
     end
 
-    def get_metadata_json(name)
-      name = name.sub('/', '-')
-      version = @cache[name]
-      metadata = @cache["#{name}-metadata"]
-
-      version = get_current_version(name) unless version
-
-      unless metadata
-        @cache["#{name}-metadata"] = metadata = get_metadata("#{name}-#{version}")
-      end
-
-      metadata
-    end
-
-    def get_metadata_json_uri(module_name)
+    def get_module_data(module_name)
       uri = URI.parse('https://forgeapi.puppetlabs.com/v3/modules/' + module_name)
       request = Net::HTTP::Get.new(uri.to_s)
       request.content_type = 'application/json'
@@ -44,16 +30,7 @@ module MetadataJsonDeps
         http.request(request)
       end
 
-      response.body
-    end
-
-    def check_deprecated_at(module_name)
-      module_name = module_name.sub('/', '-')
-      meta_complete = get_metadata_json_uri(module_name)
-      details = JSON.parse(meta_complete)
-      if details.has_key? 'deprecated_at'
-        details['deprecated_at'] != nil
-      end
+      JSON.parse(response.body)
     end
 
     private

--- a/lib/metadata_json_deps/forge_helper.rb
+++ b/lib/metadata_json_deps/forge_helper.rb
@@ -32,6 +32,30 @@ module MetadataJsonDeps
       metadata
     end
 
+    def get_metadata_json_uri(module_name)
+      uri = URI.parse(ENV['METADATA_JSON_URI_BASE'] + module_name)
+      request = Net::HTTP::Get.new(uri.to_s)
+      request.content_type = 'application/json'
+      req_options = {
+          use_ssl: uri.scheme == 'https',
+      }
+
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+
+      response.body
+    end
+
+    def check_deprecated_at(module_name)
+      module_name = module_name.sub('/', '-')
+      meta_complete = get_metadata_json_uri(module_name)
+      details = JSON.parse(meta_complete)
+      if details.has_key? 'deprecated_at'
+        details['deprecated_at'] != nil
+      end
+    end
+
     private
 
     def get_mod(name)

--- a/lib/metadata_json_deps/forge_helper.rb
+++ b/lib/metadata_json_deps/forge_helper.rb
@@ -33,7 +33,7 @@ module MetadataJsonDeps
     end
 
     def get_metadata_json_uri(module_name)
-      uri = URI.parse(ENV['METADATA_JSON_URI_BASE'] + module_name)
+      uri = URI.parse('https://forgeapi.puppetlabs.com/v3/modules/' + module_name)
       request = Net::HTTP::Get.new(uri.to_s)
       request.content_type = 'application/json'
       req_options = {

--- a/lib/metadata_json_deps/metadata_checker.rb
+++ b/lib/metadata_json_deps/metadata_checker.rb
@@ -10,16 +10,17 @@ module MetadataJsonDeps
     end
 
     def module_dependencies
-      return [] unless @metadata[:dependencies]
+      return [] unless @metadata['dependencies']
 
-      @metadata[:dependencies].map do |dep|
-        constraint = dep[:version_requirement] || '>= 0'
-        [dep[:name], SemanticPuppet::VersionRange.parse(constraint)]
+      @metadata['dependencies'].map do |dep|
+        constraint = dep['version_requirement'] || '>= 0'
+        [dep['name'], SemanticPuppet::VersionRange.parse(constraint)]
       end
     end
 
     def dependencies
       module_dependencies.map do |dependency, constraint|
+        dependency = dependency.sub('-', '/')
         current = dependency == @updated_module ? SemanticPuppet::Version.parse(@updated_module_version) : @forge.get_current_version(dependency)
         [dependency, constraint, current, constraint.include?(current)]
       end

--- a/lib/metadata_json_deps/runner.rb
+++ b/lib/metadata_json_deps/runner.rb
@@ -21,9 +21,6 @@ module MetadataJsonDeps
       message = "Comparing modules against *#{@updated_module}* version *#{@updated_module_version}*\n\n"
       if check_deprecated(@forge.get_current_version(@updated_module), @forge.get_module_data(@updated_module))
         message += "The module you are comparing against #{@updated_module.upcase} is DEPRECATED.\n"
-        puts message
-        post_to_slack(message) if @use_slack
-        post_to_logs(message) if @logs_file
         exit
       end
       @updated_module = @updated_module.sub('-', '/')

--- a/lib/metadata_json_deps/runner.rb
+++ b/lib/metadata_json_deps/runner.rb
@@ -17,24 +17,24 @@ module MetadataJsonDeps
     end
 
     def run
-      @updated_module = @updated_module.sub('-', '/')
+      @updated_module = @updated_module.sub('/', '-')
       message = "Comparing modules against *#{@updated_module}* version *#{@updated_module_version}*\n\n"
-      if check_deprecated(@forge.get_current_version(@updated_module)) || @forge.check_deprecated_at(@updated_module)
-        message += "The module you are comparing against #{@updated_module.upcase} is DEPRECATED.\n" #if check_deprecated(@forge.get_current_version(@updated_module)) || @forge.check_deprecated_at(@updated_module)
+      if check_deprecated(@forge.get_current_version(@updated_module), @forge.get_module_data(@updated_module))
+        message += "The module you are comparing against #{@updated_module.upcase} is DEPRECATED.\n"
         puts message
         post_to_slack(message) if @use_slack
         post_to_logs(message) if @logs_file
         exit
       end
+      @updated_module = @updated_module.sub('-', '/')
       @module_names.each do |module_name|
         message += "Checking *#{module_name}*\n"
-        metadata = @forge.get_metadata_json(module_name)
-        post_to_logs("\n\n") if @logs_file
-        post_to_logs(metadata) if @logs_file
+        module_name = module_name.sub('/', '-')
+        module_data = @forge.get_module_data(module_name)
+        metadata = module_data['current_release']['metadata']
         checker = MetadataJsonDeps::MetadataChecker.new(metadata, @forge, @updated_module, @updated_module_version)
         dependencies = checker.dependencies
-
-        message += "The checked module #{module_name.upcase} is DEPRECATED.\n" if check_deprecated(@forge.get_current_version(module_name)) || @forge.check_deprecated_at(module_name)
+        message += "The checked module #{module_name.upcase} is DEPRECATED.\n" if check_deprecated(@forge.get_current_version(module_name), module_data)
 
         if dependencies.empty?
           message += "\tNo dependencies listed\n\n"
@@ -42,6 +42,7 @@ module MetadataJsonDeps
         end
 
         allMatch = true
+        not_deprecated = true
         dependencies.each do |dependency, constraint, current, satisfied|
           if satisfied
             if @verbose
@@ -51,10 +52,13 @@ module MetadataJsonDeps
             allMatch = false
             message += "\t#{dependency} (#{constraint}) *doesn't match* #{current}\n"
           end
-          message += "\tThe dependency module #{dependency.upcase} is DEPRECATED.\n" if check_deprecated(current) || @forge.check_deprecated_at(module_name)
+          dependency = dependency.sub('/', '-')
+          not_deprecated = false if check_deprecated(current, @forge.get_module_data(dependency))
+
+          message += "\tThe dependency module #{dependency.upcase} is DEPRECATED.\n" if check_deprecated(current, @forge.get_module_data(dependency))
         end
 
-        message += "\tAll dependencies match\n" if allMatch
+        message += "\tAll dependencies match\n" if allMatch && not_deprecated
         message += "\n"
       end
 
@@ -64,8 +68,8 @@ module MetadataJsonDeps
     rescue Interrupt
     end
 
-    def check_deprecated(version)
-      version.to_s.eql?('999.999.999') || version.to_s.eql?('99.99.99')
+    def check_deprecated(version, module_data)
+      version.to_s.eql?('999.999.999') || version.to_s.eql?('99.99.99') || module_data['deprecated_at'] != nil
     end
 
     def return_modules(filename)

--- a/lib/metadata_json_deps/runner.rb
+++ b/lib/metadata_json_deps/runner.rb
@@ -17,14 +17,24 @@ module MetadataJsonDeps
     end
 
     def run
-
       @updated_module = @updated_module.sub('-', '/')
       message = "Comparing modules against *#{@updated_module}* version *#{@updated_module_version}*\n\n"
+      if check_deprecated(@forge.get_current_version(@updated_module)) || @forge.check_deprecated_at(@updated_module)
+        message += "The module you are comparing against #{@updated_module.upcase} is DEPRECATED.\n" #if check_deprecated(@forge.get_current_version(@updated_module)) || @forge.check_deprecated_at(@updated_module)
+        puts message
+        post_to_slack(message) if @use_slack
+        post_to_logs(message) if @logs_file
+        exit
+      end
       @module_names.each do |module_name|
         message += "Checking *#{module_name}*\n"
         metadata = @forge.get_metadata_json(module_name)
+        post_to_logs("\n\n") if @logs_file
+        post_to_logs(metadata) if @logs_file
         checker = MetadataJsonDeps::MetadataChecker.new(metadata, @forge, @updated_module, @updated_module_version)
         dependencies = checker.dependencies
+
+        message += "The checked module #{module_name.upcase} is DEPRECATED.\n" if check_deprecated(@forge.get_current_version(module_name)) || @forge.check_deprecated_at(module_name)
 
         if dependencies.empty?
           message += "\tNo dependencies listed\n\n"
@@ -41,6 +51,7 @@ module MetadataJsonDeps
             allMatch = false
             message += "\t#{dependency} (#{constraint}) *doesn't match* #{current}\n"
           end
+          message += "\tThe dependency module #{dependency.upcase} is DEPRECATED.\n" if check_deprecated(current) || @forge.check_deprecated_at(module_name)
         end
 
         message += "\tAll dependencies match\n" if allMatch
@@ -51,6 +62,10 @@ module MetadataJsonDeps
       post_to_slack(message) if @use_slack
       post_to_logs(message) if @logs_file
     rescue Interrupt
+    end
+
+    def check_deprecated(version)
+      version.to_s.eql?('999.999.999') || version.to_s.eql?('99.99.99')
     end
 
     def return_modules(filename)


### PR DESCRIPTION
If a module has version on the forge is 999.999.999, that module is considered as being deprecated
When current version is 999.999.999 new message is added e.g. 'LIAMJBENNETT/WINDOWS_FIREWALL is DEPRECATED'
