### PR TITLE
(FM-7705) Add basic parallel processes

### DIFF
--- a/metadata_json_deps.gemspec
+++ b/metadata_json_deps.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet_forge', '~> 2.2'
   s.add_runtime_dependency 'rake', '~> 12.3'
   s.add_runtime_dependency 'semantic_puppet', '~> 1.0'
+  s.add_runtime_dependency 'parallel'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
 end


### PR DESCRIPTION
Added basic parallel processes to improve run time. 

Test suite now runs ~45% faster (original ~29s, now ~16s). 

The following command which compares against 28 modules now runs ~70% faster (original ~25.4s, now ~7.4s)
`bundle exec rake 'compare_dependencies[https://gist.githubusercontent.com/eimlav/6df50eda0b1c57c1ab8c33b64c82c336/raw/managed_modules.yaml, puppetlabs/stdlib, 10.0.0, true, true]'`

